### PR TITLE
Pushwasm v0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "pushwasm"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]
-base64 = "*"
-clap = { version = "3.2.7", features = ["derive"] }
-mysql = "*"
-rpassword = "*"
-url = "*"
+anyhow = "1.0"
+base64 = "0.21"
+clap = { version = "4.2", features = ["derive"] }
+mysql = "23.0"
+rpassword = "7.2"
+url = "2.3"

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -1,0 +1,161 @@
+use clap::{Args, Parser, Subcommand, ValueEnum};
+use std::fmt::{Display, Formatter};
+use std::path::{Path, PathBuf};
+use url::Url;
+
+#[derive(Debug, Args)]
+pub struct SharedFunctionOptions {
+    #[clap(short, long, help = "Name of the function", required = true)]
+    pub name: String,
+    #[clap(long = "wasm", help = "Wasm import", value_enum, required = true)]
+    pub wasm_source: ImportSource,
+    #[clap(long = "wit", value_enum, help = "WIT import")]
+    pub wit_source: Option<ImportSource>,
+    #[clap(
+        short,
+        long,
+        help = "Force replace existing function(s)",
+        default_value = "false"
+    )]
+    pub force: bool,
+    #[clap(short, long, help = "Prompt for password", default_value = "false")]
+    pub prompt: bool,
+    #[clap(long = "abi", help = "ABI type", default_value = "canonical")]
+    pub abi_type: AbiType,
+    #[clap(
+        short,
+        long = "conn",
+        help = "Database connection string. Must begin with 'file://' or 'mysql://'"
+    )]
+    pub connection: Url,
+}
+
+#[derive(Parser)]
+#[command(
+    author,
+    version,
+    about,
+    long_about = "Creates a Wasm User-defined function"
+)]
+pub struct UserFunction {
+    #[clap(flatten)]
+    pub shared: SharedFunctionOptions,
+}
+
+#[derive(Parser)]
+#[command(
+    author,
+    version,
+    about,
+    long_about = "Creates a Wasm Table-valued function"
+)]
+pub struct TableFunction {
+    #[clap(flatten)]
+    pub shared: SharedFunctionOptions,
+}
+
+#[derive(Parser)]
+#[command(
+    author,
+    version,
+    about,
+    long_about = "Creates a Wasm User-defined aggregate function"
+)]
+pub struct AggregateFunction {
+    #[clap(flatten)]
+    pub shared: SharedFunctionOptions,
+    #[clap(
+        short = 't',
+        long = "type",
+        help = "Return type ~ RETURNS",
+        required = true
+    )]
+    pub return_type: String,
+    #[clap(
+        short,
+        long = "arg",
+        help = "Function argument types. A name will be automatically generated for each argument.",
+        required = true,
+        num_args=1..,
+    )]
+    pub args: Vec<String>,
+    #[clap(
+        short,
+        long = "state",
+        help = "State type ~ WITH STATE",
+        required = true
+    )]
+    pub state_type: String,
+    #[clap(
+        long,
+        help = "Initialization method ~ INITIALIZE WITH",
+        required = true
+    )]
+    pub init: String,
+    #[clap(long, help = "Update method ~ ITER WITH", required = true)]
+    pub iter: String,
+    #[clap(long, help = "Merge method ~ MERGE WITH", required = true)]
+    pub merge: String,
+    #[clap(long, help = "Terminate method ~ ITER WITH", required = true)]
+    pub terminate: String,
+    #[clap(long, help = "Serialize method ~ SERIALIZE WITH")]
+    pub serialize: Option<String>,
+    #[clap(long, help = "Deserialize method ~ Deserialize WITH")]
+    pub deserialize: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub enum ImportSource {
+    Base64(String),
+    Path(PathBuf),
+    Url(Url),
+}
+
+#[derive(Parser)]
+#[command(author, version, about = "Push a Wasm module into SingleStoreDB.")]
+#[command(propagate_version = true)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub functions: Functions,
+}
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Subcommand)]
+pub enum Functions {
+    #[clap(name = "udf")]
+    Udf(UserFunction),
+    #[clap(name = "tvf")]
+    Tvf(TableFunction),
+    #[clap(name = "agg")]
+    Udaf(AggregateFunction),
+}
+
+impl std::str::FromStr for ImportSource {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(if value.starts_with("http") {
+            Self::Url(Url::parse(value).map_err(|e| format!("Could not parse URL: {}", e))?)
+        } else if Path::new(&value).exists() {
+            Self::Path(Path::new(value).to_path_buf())
+        } else {
+            Self::Base64(value.to_string())
+        })
+    }
+}
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum AbiType {
+    Basic,
+    Canonical,
+}
+
+impl Display for AbiType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            AbiType::Basic => "BASIC",
+            AbiType::Canonical => "CANONICAL",
+        };
+        write!(f, "{}", s)
+    }
+}

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -178,7 +178,7 @@ pub enum Functions {
     Udf(UserFunction),
     #[clap(name = "tvf")]
     Tvf(TableFunction),
-    #[clap(name = "agg")]
+    #[clap(name = "udaf")]
     Udaf(AggregateFunction),
 }
 

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -106,7 +106,7 @@ pub struct ManualAggregateImports {
     pub terminate: Option<String>,
     #[clap(long, help = "Serialize method ~ SERIALIZE WITH")]
     pub serialize: Option<String>,
-    #[clap(long, help = "Deserialize method ~ Deserialize WITH")]
+    #[clap(long, help = "Deserialize method ~ DESERIALIZE WITH")]
     pub deserialize: Option<String>,
 }
 

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -153,9 +153,7 @@ impl ImportSource {
                     .expect("Invalid base64");
                 from_utf8(&decoded).expect("Invalid UTF-8").to_string()
             }
-            ImportSource::Path(path) => read_to_string(path)
-                .expect("Could not read file")
-                .to_string(),
+            ImportSource::Path(path) => read_to_string(path).expect("Could not read file"),
             ImportSource::Url(_) => {
                 todo!("Downloading wit from URL is not supported!")
             }

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -129,7 +129,7 @@ impl ManualAggregateImports {
             exit_with("terminate");
         }
 
-        if self.serialize.is_none() != self.serialize.is_none() {
+        if self.serialize.is_none() != self.deserialize.is_none() {
             eprintln!("Aggregate functions require both serialize and deserialize functions");
             exit(1);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,14 @@
-use clap::{arg, Arg, ArgAction, Command};
-use mysql::*;
+mod arguments;
+mod query_builder;
+
+use crate::arguments::{Cli, Functions};
+use crate::query_builder::QueryBuilder;
+use anyhow::Context;
+use clap::Parser;
 use mysql::prelude::*;
+use mysql::*;
 use rpassword::prompt_password;
 use std::fs;
-use std::path::PathBuf;
 use std::process::exit;
 use url::Url;
 
@@ -16,80 +21,29 @@ fn parse_url(s: &str) -> Url {
     url.unwrap()
 }
 
-fn main() {
-    // Parse arguments.
-    let matches = Command::new("pushwasm")
-        .about("Push a Wasm module into SingleStoreDB.")
-        .subcommand_required(false)
-        .arg_required_else_help(true)
-        .arg(
-            Arg::new("WITPATH")
-                .short('w')
-                .long("wit")
-                .help("The WIT file path")
-                .takes_value(true)
-                .value_parser(clap::value_parser!(PathBuf))
-        )
-        .arg(
-            Arg::new("ABITYPE")
-                .short('a')
-                .long("abi")
-                .help("The ABI to use")
-                .takes_value(true)
-                .value_parser(["basic", "canonical"])
-                .default_value("canonical")
-        )
-        .arg(
-            Arg::new("FORCE")
-                .short('f')
-                .long("force")
-                .help("Replace UDF/TVF if it exists already")
-                .action(ArgAction::SetTrue),
-        )
-        .arg(
-            Arg::new("TVF")
-                .short('t')
-                .long("tvf")
-                .help("Deploy a TVF instead of a UDF")
-                .action(ArgAction::SetTrue),
-        )
-        .arg(
-            Arg::new("PROMPT")
-                .short('p')
-                .long("prompt")
-                .help("Prompt to enter password on console")
-                .action(ArgAction::SetTrue),
-        )
-        .arg(arg!(<CONN> "The database connection string")
-            .help("Database connection information; must start with 'file://' \
-                   or 'mysql://'.  If a file is provided, the connection \
-                   string will be read from it.\nExample: \
-                   mysql://user:pass@hostname:3306/dbname"))
-        .arg(arg!(<WASMPATH> "The Wasm module path")
-            .value_parser(clap::value_parser!(PathBuf)))
-        .arg(arg!(<FUNCNAME> "The Wasm function name"))
-        .get_matches();
+fn main() -> anyhow::Result<()> {
+    let args = Cli::parse();
 
-    let conn_spec = matches.get_one::<String>("CONN").expect("required");
-    let func_name = matches.get_one::<String>("FUNCNAME").expect("required");
-    let wasm_path = matches.get_one::<PathBuf>("WASMPATH").expect("required");
-    let wit_path = matches.get_one::<PathBuf>("WITPATH");
-    let abi = matches.get_one::<String>("ABITYPE");
-    let force = *matches.get_one::<bool>("FORCE").unwrap_or_else(|| &false);
-    let tvf = *matches.get_one::<bool>("TVF").unwrap_or_else(|| &false);
-    let prompt = *matches.get_one::<bool>("PROMPT").unwrap_or_else(|| &false);
-    let has_wit = wit_path.is_some();
-    let func_kind = if tvf { "TVF" } else { "UDF" };
-    
-    // Convert the connection specifier URL to a connection string.  If it 
+    // Extract the shared config
+    let shared = match &args.functions {
+        Functions::Udf(f) => &f.shared,
+        Functions::Tvf(f) => &f.shared,
+        Functions::Udaf(f) => &f.shared,
+    };
+
+    // Convert the connection specifier URL to a connection string.  If it
     // begins with file://, we'll read the connection string from a file.
-    let url = parse_url(conn_spec);
-    let mut conn_url: Url = match url.scheme() {
+    let url = &shared.connection;
+    let mut conn_url = match shared.connection.scheme() {
         "mysql" => url.clone(),
         "file" => {
             let file_res = fs::read_to_string(url.path());
             if let Err(e) = &file_res {
-                eprintln!("Error reading connection info from file '{}': {}", url.path(), e);
+                eprintln!(
+                    "Error reading connection info from file '{}': {}",
+                    url.path(),
+                    e
+                );
                 exit(1);
             }
             let new_url = parse_url(file_res.unwrap().as_str());
@@ -98,7 +52,7 @@ fn main() {
                 exit(1);
             }
             new_url
-        },
+        }
         _ => {
             eprintln!("Invalid config specification.  Must begin with 'file://' or 'mysql://'");
             exit(1);
@@ -106,81 +60,31 @@ fn main() {
     };
 
     // Prompt for password, if requested.
-    let mut password: Option<String> = None;
-    if prompt {
-        let pass_res = prompt_password("Password: ");
-        if let Err(e) = pass_res {
-            eprintln!("Error reading password: {}", e);
-            exit(1);
-        }
-        password = Some(pass_res.unwrap());
-    }
-    if let Some(p) = password {
-        if let Err(_) = conn_url.set_password(Some(&p)) {
-            eprintln!("Error setting password");
-            exit(1);
-        }
-    }
+    if shared.prompt {
+        let pass = prompt_password("Password: ").context("Error reading password")?;
+        conn_url
+            .set_password(Some(&pass))
+            .map_err(|()| anyhow::anyhow!("Couldn't read password"))
+            .context("Could not set password")?;
+    };
 
     // Get the final connection string.
     let conn_str: String = conn_url.into();
 
-    // Generate the CREATE FUNCTION template.
-    let mut stmt_str = String::from("CREATE ");
-    if force {
-        stmt_str += "OR REPLACE ";
-    }
-    stmt_str += format!("FUNCTION {} ", func_name).as_str();
-    if tvf {
-        stmt_str += "RETURNS TABLE ";
-    }
-    stmt_str += format!("AS WASM ABI {} FROM BASE64 ?", abi.unwrap()).as_str();
-    if has_wit {
-        stmt_str = stmt_str + " WITH WIT FROM BASE64 ?";
-    }
-
-    // Read the Wasm module data and base-64 encode it.
-    let file_res = fs::read(wasm_path);
-    if let Err(e) = &file_res {
-        eprintln!("Error reading Wasm file '{}': {}", wasm_path.to_str().unwrap(), e);
-        exit(1);
-    }
-    let encoded_wasm = base64::encode(file_res.unwrap());
-
-    // Read the WIT data and base-64 encode it.
-    let mut encoded_wit = String::from("");
-    if let Some(wit_path) = wit_path {
-        let file_res = fs::read(wit_path);
-        if let Err(e) = &file_res {
-            eprintln!("Error reading WIT file '{}': {}", wit_path.to_str().unwrap(), e);
-            exit(1);
-        }
-        encoded_wit = base64::encode(file_res.unwrap());
-    }
-
     // Open the SQL connection using the connection string.
-    let pool = Pool::new(conn_str.as_str());
-    if let Err(e) = pool {
-        eprintln!("Error opening SQL connection: {}", e);
-        exit(1);
-    }
-    let conn = pool.unwrap().get_conn();
-    if let Err(e) = conn {
-        eprintln!("Error opening SQL connection: {}", e);
-        exit(1);
-    }
-    let mut conn = conn.unwrap();
+    let opts = Opts::from_url(&conn_str)?;
+    let mut conn = Conn::new(opts).context("Error opening SQL connection")?;
 
-    // Execute the CREATE FUNCTION statement with the encoded Wasm and WIT data.
-    let mut p = vec![encoded_wasm];
-    if has_wit {
-        p.push(encoded_wit);
-    }
-    //let p = (encoded_wasm, encoded_wit);
-    let exec_res = conn.exec::<String, _, _>(stmt_str, p);
-    if let Err(e) = exec_res {
-        eprintln!("Error while creating {}: {}", &func_kind, e);
-        exit(1);
-    }
-    println!("Wasm {} '{}' was created successfully.", &func_kind, &func_name);
+    // Generate the query body & params
+    let mut params = vec![];
+    let query_str = args.functions.build(&mut params);
+
+    // Execute the query
+    conn.exec::<String, _, _>(query_str, params)
+        .map_err(|e| anyhow::anyhow!("Error executing query: {}", e))
+        .context("Could not create function")?;
+
+    println!("Wasm function was created successfully.");
+
+    Ok(())
 }

--- a/src/query_builder.rs
+++ b/src/query_builder.rs
@@ -195,7 +195,7 @@ fn try_extract_member_functions_from_wit(source: String) -> HashMap<MemberFuncti
             // Take the string up to the first colon
             if let Some(name) = line.split(':').next() {
                 if let Some(func) = MemberFunction::from_name(name) {
-                    if let Some(duplicate) = functions.insert(func, name.replace("-", "_")) {
+                    if let Some(duplicate) = functions.insert(func, name.replace('-', "_")) {
                         eprintln!("Duplicate match for function name: {name} vs {duplicate}");
                         exit(1);
                     }

--- a/src/query_builder.rs
+++ b/src/query_builder.rs
@@ -1,0 +1,151 @@
+use crate::arguments::{AggregateFunction, Functions, ImportSource, TableFunction, UserFunction};
+use base64::Engine;
+use std::fs;
+
+pub trait QueryBuilder {
+    fn build(&self, args: &mut Vec<String>) -> String;
+}
+
+impl QueryBuilder for ImportSource {
+    fn build(&self, args: &mut Vec<String>) -> String {
+        match self {
+            ImportSource::Base64(s) => {
+                args.push(s.clone());
+                "FROM BASE64 ?"
+            }
+            ImportSource::Path(p) => {
+                let file_content = fs::read(p).expect("Could not read file");
+                let encoded = base64::engine::general_purpose::STANDARD.encode(file_content);
+                args.push(encoded);
+                "FROM BASE64 ?"
+            }
+            ImportSource::Url(u) => {
+                args.push(u.to_string());
+                "FROM URL ?"
+            }
+        }
+        .to_string()
+    }
+}
+
+impl QueryBuilder for UserFunction {
+    fn build(&self, args: &mut Vec<String>) -> String {
+        let wasm_source = self.shared.wasm_source.build(args);
+        let wit_source = self
+            .shared
+            .wit_source
+            .as_ref()
+            .map(|w| format!("WITH WIT {}", w.build(args)))
+            .unwrap_or_default();
+        format!(
+            "
+            CREATE {force} FUNCTION {name}
+            AS WASM ABI {abi}
+            {wasm_source}
+            {wit_source}
+            ",
+            name = self.shared.name,
+            force = if self.shared.force { "OR REPLACE" } else { "" },
+            abi = self.shared.abi_type,
+        )
+    }
+}
+
+impl QueryBuilder for TableFunction {
+    fn build(&self, args: &mut Vec<String>) -> String {
+        let wasm_source = self.shared.wasm_source.build(args);
+        let wit_source = self
+            .shared
+            .wit_source
+            .as_ref()
+            .map(|w| format!("WITH WIT {}", w.build(args)))
+            .unwrap_or_default();
+        format!(
+            "
+            CREATE {force} FUNCTION {name}
+            RETURNS TABLE
+            AS WASM ABI {abi} 
+            {wasm_source}
+            {wit_source}
+            ",
+            name = self.shared.name,
+            force = if self.shared.force { "OR REPLACE" } else { "" },
+            abi = self.shared.abi_type,
+        )
+    }
+}
+
+impl QueryBuilder for AggregateFunction {
+    fn build(&self, args: &mut Vec<String>) -> String {
+        let wasm_source = self.shared.wasm_source.build(args);
+        let wit_source = self
+            .shared
+            .wit_source
+            .as_ref()
+            .map(|w| w.build(args))
+            .unwrap_or_default();
+        let args = if args.len() == 1 {
+            // The name of the argument is omitted for single args
+            self.args[0].clone()
+        } else {
+            // A unique argument name is generated for each args, e.g.
+            // "a int, b int, c int, ..."
+            let generate_var_names = |(i, arg_type)| {
+                let var_name_as_letter = ('a' as usize + i) as u8 as char;
+                format!("{var_name_as_letter} {arg_type}")
+            };
+
+            self.args
+                .iter()
+                .enumerate()
+                .map(generate_var_names)
+                .collect::<Vec<_>>()
+                .join(",")
+        };
+        format!(
+            "
+            CREATE {force} AGGREGATE {name}({args})
+            RETURNS {return_type}
+            WITH STATE {state}
+            AS WASM ABI {abi} 
+            {wasm_source}
+            {wit_source}
+            INITIALIZE WITH {init}
+            ITERATE WITH {iter}
+            MERGE WITH {merge}
+            TERMINATE WITH {terminate}
+            {serialize}
+            {deserialize}
+            ",
+            name = self.shared.name,
+            force = if self.shared.force { "OR REPLACE" } else { "" },
+            return_type = self.return_type,
+            state = self.state_type,
+            abi = self.shared.abi_type,
+            init = self.init,
+            iter = self.iter,
+            merge = self.merge,
+            terminate = self.terminate,
+            serialize = self
+                .serialize
+                .as_ref()
+                .map(|s| format!("SERIALIZE WITH {}", s))
+                .unwrap_or_default(),
+            deserialize = self
+                .deserialize
+                .as_ref()
+                .map(|s| format!("DESERIALIZE WITH {}", s))
+                .unwrap_or_default(),
+        )
+    }
+}
+
+impl QueryBuilder for Functions {
+    fn build(&self, args: &mut Vec<String>) -> String {
+        match self {
+            Functions::Udf(f) => f.build(args),
+            Functions::Tvf(f) => f.build(args),
+            Functions::Udaf(f) => f.build(args),
+        }
+    }
+}

--- a/src/query_builder.rs
+++ b/src/query_builder.rs
@@ -124,12 +124,19 @@ impl QueryBuilder for AggregateFunction {
                 format!("{var_name_as_letter} {arg_type}")
             };
 
-            self.args
+            let generated_args = self
+                .args
                 .iter()
                 .enumerate()
                 .map(generate_var_names)
-                .collect::<Vec<_>>()
-                .join(",")
+                .collect::<Vec<_>>();
+
+            if generated_args.len() > 26 {
+                eprintln!("Too many arguments for an aggregate function. Maximum is 26.");
+                exit(1);
+            }
+
+            generated_args.join(",")
         };
         format!(
             "


### PR DESCRIPTION
## General

This PR splits the CLI up into three subcommands:
* udf: Create a user-defined function from a wasm module
* tvf: Create a table-valued function from a wasm module
* agg: Create a user-defined aggregate function from a wasm module

### UDF

```sh
pushwasm udf -n my_function --wasm extension.wasm --wit extension.wit --force --abi canonical -c 'mysql://root@ip/my_db
```

### TVF

```sh
pushwasm tvf -n my_table_function --wasm extension.wasm --wit extension.wit --force --abi canonical -c 'mysql://root@ip/my_db
```

### Agg

```sh
pushwasm udaf -n my_aggregate  --wasm extension.wasm --wit extension.wit -f --abi canonical -c 'mysql://root@localhost/udas' 
--arg 'int not null' 
--state handle
--type 'int not null' 
--init handle_init 
--iter handle_add 
--merge handle_merge 
--terminate handle_get 
--serialize handle_serialize 
--deserialize handle_deserialize
```
alternatively the member functions can be auto-deduced (in certain cases) from the WIT spec if provided:
```sh
pushwasm agg -n my_aggregate  --wasm extension.wasm --wit extension.wit -f --abi canonical -c 'mysql://root@localhost/udas' 
--arg 'int not null' 
--state handle
--type 'int not null' 
```

## Technical

* The CLI now uses struct derives to define the argument structure
* The `QueryBuilder` trait constructs the query string for each subcommand & structure
* Pin specific crate dependencies to prevent breakages in the future

